### PR TITLE
fix: add missing include

### DIFF
--- a/include/export/josepp/crypto.hpp
+++ b/include/export/josepp/crypto.hpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <memory>
 #include <sstream>
+#include <functional>
 
 #include <josepp/types.hpp>
 #include <josepp/digest.hpp>

--- a/include/export/josepp/digest.hpp
+++ b/include/export/josepp/digest.hpp
@@ -44,6 +44,8 @@ public:
 public:
 	static const EVP_MD *md(digest::type t) {
 		switch (t) {
+		default:
+			[[fallthrough]];
 		case type::SHA256:
 			return EVP_sha256();
 		case type::SHA384:

--- a/include/export/josepp/sstring.hh
+++ b/include/export/josepp/sstring.hh
@@ -36,7 +36,9 @@ public:
 
 	secure_allocator() noexcept = default;
 
-	secure_allocator(const secure_allocator &) noexcept {}
+	secure_allocator(const secure_allocator &) noexcept
+		: std::allocator<T>()
+	{}
 
 	template <class U>
 	explicit secure_allocator(const secure_allocator<U> &) noexcept {}


### PR DESCRIPTION
return default SHA for digest
explicitly init base constructor in secure_string