### PR TITLE
Fix "invalid use of incomplete type ‘std::stringstream'"

### DIFF
--- a/src/claims.cpp
+++ b/src/claims.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <sstream>
+
 #include <josepp/claims.hpp>
 #include <josepp/b64.hpp>
 #include <josepp/tools.hpp>

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include <iostream>
+#include <sstream>
 
 #include <josepp/tools.hpp>
 #include <josepp/b64.hpp>


### PR DESCRIPTION
Include <sstream> to fix this issue for gcc8 on linux